### PR TITLE
Enforce C locale

### DIFF
--- a/src/mobi/hsz/idea/gitignore/util/exec/ExternalExec.java
+++ b/src/mobi/hsz/idea/gitignore/util/exec/ExternalExec.java
@@ -191,8 +191,9 @@ public class ExternalExec {
 
         try {
             final String cmd = bin + " " + command;
+            final String[] env = { "LANG=C" };
             final File workingDirectory = directory != null ? new File(directory.getPath()) : null;
-            final Process process = Runtime.getRuntime().exec(cmd, null, workingDirectory);
+            final Process process = Runtime.getRuntime().exec(cmd, env, workingDirectory);
 
             ProcessHandler handler = new BaseOSProcessHandler(process, StringUtil.join(cmd, " "), null) {
                 @NotNull


### PR DESCRIPTION
Fixes #507.

Git’s output here is only ASCII, so setting LANG=C doesn’t change for non-ASCII filenames:

```console
$ mkdir test && cd test
$ git init
$ touch 😼
$ git clean -dn
Würde "\360\237\230\274" löschen
$ LANG=C git clean -dn
Would remove "\360\237\230\274"
```

BTW: I’m not sure if you parse that correctly in any case, but it’s not influenced by this PR.