### PR TITLE
Allow for both duplicates and comments to be removed with checkboxes during .ignore configuration

### DIFF
--- a/resources/messages/IgnoreBundle.properties
+++ b/resources/messages/IgnoreBundle.properties
@@ -71,8 +71,8 @@ file.templateSection=\#\#\# {0} template
 global.cancel=_Cancel
 global.generate=_Generate
 global.create=_Create
-global.generate.without.duplicates=Generate without _duplicates
-global.generate.without.comments=Generate without _comments and empty lines
+global.generate.without.duplicates=Generate without duplicates
+global.generate.without.comments=Generate without comments and empty lines
 
 highlighter.brackets=Brackets
 highlighter.comment=Comment


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/16655930/92433635-a3325180-f16b-11ea-942b-c3fa53a2db4c.png)

# After
![Screenshot 2020-09-08 at 12 22 04 AM](https://user-images.githubusercontent.com/16655930/92433390-e93ae580-f16a-11ea-99fc-1a68553ff76f.png)

I removed the dropdown menu on the `Generate` button and moved it over to the checkboxes in the image provided. This allows for the action where both duplicates and comments are removed, which was not possible.

I made the design choice to refactor this behavior away from the dropdown button because just adding another option would clutter the UI and makes the button do too much than is necessary.
This also allowed me to remove the `OptionOkAction` class and the removal of parameters from `performAppendAction`.

The images shown have an incorrect UI for templates than is expected. This is because of a change made prior to this commit and has no cause by my changes.

Any tweaking of the checkbox positions, style, or accessibility for a better UX is welcome if noted.
The text may also be too verbose, but I kept it effectively identical to the original
