### PR TITLE
Stop "you are editing a file that is ignored" banner from displaying if file is not editable.

### DIFF
--- a/src/main/kotlin/mobi/hsz/idea/gitignore/daemon/IgnoredEditingNotificationProvider.kt
+++ b/src/main/kotlin/mobi/hsz/idea/gitignore/daemon/IgnoredEditingNotificationProvider.kt
@@ -43,6 +43,9 @@ class IgnoredEditingNotificationProvider(project: Project) : EditorNotificationP
         if (DumbService.isDumb(project)) {
             return null
         }
+        if (!file.isWritable()) {
+            return null
+        }
         if (!settings.notifyIgnoredEditing || !changeListManager.isIgnoredFile(file) && !manager.isFileIgnored(file)) {
             return null
         }


### PR DESCRIPTION
Fixes #738, by checking if the file can be edited before displaying the banner telling them they're editing it.