### PR TITLE
Fix a minor English grammar problem in user-facing text

### DIFF
--- a/src/main/resources/messages/IgnoreBundle.properties
+++ b/src/main/resources/messages/IgnoreBundle.properties
@@ -47,7 +47,7 @@ quick.fix.relative.entry=Remove relative part
 quick.fix.syntax.entry=Suggest correct value
 
 daemon.lineMarker.directory=Directory entry
-daemon.ignoredEditing=You are editing a file which is ignored
+daemon.ignoredEditing=You are editing a file that is ignored
 daemon.missingGitignore=Missing .gitignore file in Git project
 daemon.missingGitignore.create=Create .gitignore
 daemon.cancel=Cancel


### PR DESCRIPTION
Correcting wording of user-facing text when editing an ignored file.

For details on this tricky English grammar rule about restrictive vs. nonrestrictive clauses, see https://www.grammarly.com/blog/which-vs-that/

Fixes this github issue: https://github.com/JetBrains/idea-gitignore/issues/868