### PR TITLE
Remove unnecessary property

### DIFF
--- a/src/main/kotlin/mobi/hsz/idea/gitignore/daemon/IgnoredEditingNotificationProvider.kt
+++ b/src/main/kotlin/mobi/hsz/idea/gitignore/daemon/IgnoredEditingNotificationProvider.kt
@@ -22,7 +22,6 @@ import javax.swing.JComponent
  */
 class IgnoredEditingNotificationProvider(project: Project) : EditorNotificationProvider {
 
-    private val notifications = EditorNotifications.getInstance(project)
     private val settings = service<IgnoreSettings>()
     private val manager = project.service<IgnoreManager>()
     private val changeListManager = ChangeListManager.getInstance(project)


### PR DESCRIPTION
`notifications` seems to be a leftover from [this 2022 commit](https://github.com/JetBrains/idea-gitignore/commit/c8143982a7ba0a7fa0a0f02e3ee871d80463e2b6).